### PR TITLE
HW-4

### DIFF
--- a/accounting/config/services.yaml
+++ b/accounting/config/services.yaml
@@ -38,3 +38,8 @@ services:
         factory: [ '@doctrine.orm.entity_manager', getRepository ]
         arguments:
             - Accounting\Entity\Balance
+
+    Accounting\Repository\TaskRepository:
+        factory: [ '@doctrine.orm.entity_manager', getRepository ]
+        arguments:
+            - Accounting\Entity\Task

--- a/accounting/migrations/Version20220522072019.php
+++ b/accounting/migrations/Version20220522072019.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220522072019 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE tasks (id VARCHAR(36) NOT NULL, name VARCHAR(64) NOT NULL, jira_id VARCHAR(32) DEFAULT \'\' NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, public_id VARCHAR(36) NOT NULL, status VARCHAR(32) NOT NULL, PRIMARY KEY(id))');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('DROP TABLE tasks');
+    }
+}

--- a/accounting/src/Consumer/TaskConsumer.php
+++ b/accounting/src/Consumer/TaskConsumer.php
@@ -2,6 +2,9 @@
 
 namespace Accounting\Consumer;
 
+use Accounting\Entity\Task;
+use Accounting\Repository\TaskRepository;
+use Accounting\Service\Task\TaskService;
 use Accounting\Service\Transaction\TaskTransactionService;
 use OldSound\RabbitMqBundle\RabbitMq\ConsumerInterface;
 use PhpAmqpLib\Message\AMQPMessage;
@@ -11,10 +14,17 @@ class TaskConsumer implements ConsumerInterface
     private const TASK_ASSIGNED_EVENT_NAME = 'Task.Assigned';
     private const TASK_COMPLETED_EVENT_NAME = 'Task.Completed';
     private TaskTransactionService $taskTransactionService;
+    private TaskService $taskService;
+    private TaskRepository $taskRepository;
 
-    public function __construct(TaskTransactionService $taskTransactionService)
-    {
+    public function __construct(
+        TaskTransactionService $taskTransactionService,
+        TaskService $taskService,
+        TaskRepository $taskRepository
+    ) {
         $this->taskTransactionService = $taskTransactionService;
+        $this->taskService = $taskService;
+        $this->taskRepository = $taskRepository;
     }
 
     public function execute(AMQPMessage $msg)
@@ -28,14 +38,25 @@ class TaskConsumer implements ConsumerInterface
         switch ($content['event_name']) {
             case self::TASK_ASSIGNED_EVENT_NAME:
                 if ($content['data']['status'] === 'assigned') {
+                    $task = $this->taskRepository->findOneBy([
+                        'publicId' => $content['data']['public_id']
+                    ]) ?? new Task();
+
                     $this->taskTransactionService->createAssignedTaskTransaction($content['data']);
+                    $this->taskService->updateStatus($task, $content['data']['status']);
                 }
 
                 break;
 
             case self::TASK_COMPLETED_EVENT_NAME:
                 if ($content['data']['status'] === 'completed') {
+                    $task = $this->taskRepository->findOneBy([
+                            'publicId' => $content['data']['public_id']
+                        ]) ?? new Task();
+
+
                     $this->taskTransactionService->createCompletedTaskTransaction($content['data']);
+                    $this->taskService->updateStatus($task, $content['data']['status']);
                 }
 
                 break;

--- a/accounting/src/Consumer/TaskStreamConsumer.php
+++ b/accounting/src/Consumer/TaskStreamConsumer.php
@@ -2,6 +2,7 @@
 
 namespace Accounting\Consumer;
 
+use Accounting\Service\Task\TaskService;
 use Accounting\Service\Transaction\TaskTransactionService;
 use OldSound\RabbitMqBundle\RabbitMq\ConsumerInterface;
 use PhpAmqpLib\Message\AMQPMessage;
@@ -10,10 +11,14 @@ class TaskStreamConsumer implements ConsumerInterface
 {
     private const TASK_CREATED_EVENT_NAME = 'Task.Created';
     private TaskTransactionService $taskTransactionService;
+    private TaskService $taskService;
 
-    public function __construct(TaskTransactionService $taskTransactionService)
-    {
+    public function __construct(
+        TaskTransactionService $taskTransactionService,
+        TaskService $taskService
+    ) {
         $this->taskTransactionService = $taskTransactionService;
+        $this->taskService = $taskService;
     }
 
     public function execute(AMQPMessage $msg)
@@ -29,6 +34,8 @@ class TaskStreamConsumer implements ConsumerInterface
                 if ($content['data']['status'] === 'assigned') {
                     $this->taskTransactionService->createAssignedTaskTransaction($content['data']);
                 }
+
+                $this->taskService->createTask($content['data']);
 
                 break;
         }

--- a/accounting/src/Entity/Task.php
+++ b/accounting/src/Entity/Task.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Accounting\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @ORM\Entity(repositoryClass="Accounting\Repository\TaskRepository")
+ * @ORM\Table(name="tasks")
+ */
+class Task
+{
+    public const STATUS_ASSIGNED = 'assigned';
+    public const STATUS_COMPLETED = 'completed';
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="string", length=36)
+     * @ORM\GeneratedValue(strategy="CUSTOM")
+     * @ORM\CustomIdGenerator(class="Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator")
+     */
+    protected string $id = '';
+
+    /**
+     * @ORM\Column(type="string", length=64)
+     */
+    protected string $name = '';
+
+    /**
+     * @ORM\Column(type="string", length=32, options={"default" : ""})
+     */
+    protected string $jiraId = '';
+
+    /**
+     * @ORM\Column(type="datetime")
+     */
+    protected \DateTime $createdAt;
+
+    /**
+     * @ORM\Column(type="datetime")
+     */
+    protected \DateTime $updatedAt;
+
+    /**
+     * @ORM\Column(type="string", length=36)
+     */
+    protected string $publicId = '';
+
+    /**
+     * @ORM\Column(type="string", length=32)
+     */
+    protected string $status = self::STATUS_ASSIGNED;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTime();
+        $this->updatedAt = new \DateTime();
+        $this->publicId = Uuid::v4()->toRfc4122();
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getJiraId(): string
+    {
+        return $this->jiraId;
+    }
+
+    public function setJiraId(string $jiraId): void
+    {
+        $this->jiraId = $jiraId;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): void
+    {
+        $this->status = $status;
+    }
+
+    public function setUpdatedAt(\DateTime $updatedAt): void
+    {
+        $this->updatedAt = $updatedAt;
+    }
+
+    public function getPublicId(): string
+    {
+        return $this->publicId;
+    }
+
+    public function setPublicId(string $publicId): void
+    {
+        $this->publicId = $publicId;
+    }
+}

--- a/accounting/src/Repository/TaskRepository.php
+++ b/accounting/src/Repository/TaskRepository.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Accounting\Repository;
+
+use Doctrine\ORM\EntityRepository;
+
+class TaskRepository extends EntityRepository
+{
+}

--- a/accounting/src/Service/Task/TaskService.php
+++ b/accounting/src/Service/Task/TaskService.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Accounting\Service\Task;
+
+use Accounting\Entity\Task;
+use Doctrine\ORM\EntityManagerInterface;
+
+class TaskService
+{
+    private EntityManagerInterface $entityManager;
+
+    public function __construct(
+        EntityManagerInterface $entityManager
+    ) {
+        $this->entityManager = $entityManager;
+    }
+
+    public function createTask(array $data): void
+    {
+        $task = new Task();
+        $task->setName($data['name']);
+        $task->setJiraId($data['jira_id']);
+        $task->setPublicId($data['public_id']);
+        $task->setStatus($data['status']);
+
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+    }
+
+    public function updateStatus(Task $task, string $status): void
+    {
+        $task->setStatus($status);
+
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+    }
+}

--- a/accounting/src/Service/Transaction/TaskTransactionService.php
+++ b/accounting/src/Service/Transaction/TaskTransactionService.php
@@ -54,8 +54,6 @@ class TaskTransactionService
         $transaction->setUser($user);
         $transaction->setMeta([
             'task_public_id' => $data['public_id'],
-            'task_name' => $data['name'],
-            'task_jira_id' => $data['jira_id'],
         ]);
 
         $this->entityManager->persist($transaction);
@@ -76,8 +74,6 @@ class TaskTransactionService
         $transaction->setUser($user);
         $transaction->setMeta([
             'task_public_id' => $data['public_id'],
-            'task_name' => $data['name'],
-            'task_jira_id' => $data['jira_id'],
         ]);
 
         $this->entityManager->persist($transaction);

--- a/error-handling-strategy.md
+++ b/error-handling-strategy.md
@@ -4,4 +4,5 @@
   * send user input data, check if we created data and produced necessary events
   * send mocked MB data to consumers, check if we created data and produced necessary events
 4. Add transactional outbox pattern to save events in DB table before sending to MB - allows us to avoid lost messages if MB is down
+UPD: retry/ack strategy is enough instead of transactional outbox
 5. Add dead letter DB table to save "invalid" events to forward them to the special consumer.

--- a/how-to-migrate-to-new-task-event-schema.md
+++ b/how-to-migrate-to-new-task-event-schema.md
@@ -4,9 +4,11 @@ We need to add a new field to the task entity. As a result we should change out 
 
 1. We have the first version schema of the **Task.Created** event: [1.json](json-schema/task/created/1.json).
 2. Create a new version of event schema [2.json](json-schema/task/created/2.json). With a new field.
-3. Create a new consumer for the new event version (in my case I didn't have the first consumer version, so, I created it for the second version)
-4. Change the event to the 2nd version in producer [TaskController::createTask()](task-tracker/src/Controller/TaskController.php)
-5. Check if we receive 2nd version in the created consumer.
-6. Now we can remove the previous consumer and previous producer.
-7. Profit
+3. Create DB migration to the new version (add a new optional field) in the task service
+4. Create DB migration to the new version (add a new optional field) in the accounting/analytics service
+5. Create a new consumer for the new event version (in my case I didn't have the first consumer version, so, I created it for the second version)
+6. Change the event to the 2nd version in producer [TaskController::createTask()](task-tracker/src/Controller/TaskController.php)
+7. Check if we receive 2nd version in the created consumer.
+8. Now we can remove the previous consumer and previous producer.
+9. Profit
 


### PR DESCRIPTION
@davydovanton @f213 🖖

- improved error handling strategy, a new event schema migration after HW analysis meeting
- I didn't make a divided analytics service and decided to implement it in the accounting, and I didn't store tasks in the service. I hoped that storing its' data in the transaction meta array would be enough but it wouldn't. So, I added task storing functionality to the accounting/analytics service.

Some thoughts about the system compared with its' first blueprint version.
 - I didn't expect that storing almost the same data in the different services would be the usual way. Actually, I believed that we could make sync requests to the services to fetch some needed data.
 - I didn't think about event schema and its evolution. The schema registry is a very convenient tool to control it.
 - it turned out that the simple functionality might be hard to implement the right way in all services (for example we should take into account event ordering and error handling for CUD events)
- and yep, I found that I have so many directions and topics to grow and improve.

Thank you for this course! 🙂